### PR TITLE
set correct resolv.conf when no stub listener is enabled

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,3 @@
+exclude_paths:
+  - .github
+  - .ansible-lint

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,3 @@
+---
 exclude_paths:
   - .github
-  - .ansible-lint

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,2 @@
+# This file contains ignores rule violations for ansible-lint
+roles/systemd_timesyncd/tasks/package.yml var-naming[no-role-prefix]

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: damex
 name: systemd
-version: 1.2.8
+version: 0.2.8
 readme: README.md
 authors:
   - Roman Kuzmitskii <ansible@damex.org>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: damex
 name: systemd
-version: 0.2.8
+version: 1.2.8
 readme: README.md
 authors:
   - Roman Kuzmitskii <ansible@damex.org>

--- a/roles/systemd_hostnamed/tasks/systemd_service.yml
+++ b/roles/systemd_hostnamed/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_hostnamed_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_hostnamed_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_journald/tasks/systemd_service.yml
+++ b/roles/systemd_journald/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_journald_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_journald_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_localed/tasks/systemd_service.yml
+++ b/roles/systemd_localed/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_localed_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_localed_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_logind/tasks/systemd_service.yml
+++ b/roles/systemd_logind/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_logind_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_logind_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_networkd/tasks/systemd_service.yml
+++ b/roles/systemd_networkd/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_networkd_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_networkd_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_pstore/tasks/systemd_service.yml
+++ b/roles/systemd_pstore/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_pstore_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_pstore_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_resolved/tasks/resolv.conf.yml
+++ b/roles/systemd_resolved/tasks/resolv.conf.yml
@@ -1,8 +1,18 @@
 ---
-- name: Ensure resolv.conf
+- name: ensure resolv.conf (classic)
+  ansible.builtin.file:
+    src: /run/systemd/resolve/resolv.conf
+    dest: /etc/resolv.conf
+    state: link
+    force: true
+  become: true
+  when: ( systemd_resolved_dnsstublistener | regex_search("no|false|0", ignorecase=True) )
+
+- name: ensure resolv.conf (stub)
   ansible.builtin.file:
     src: /run/systemd/resolve/stub-resolv.conf
     dest: /etc/resolv.conf
     state: link
     force: true
   become: true
+  when: ( systemd_resolved_dnsstublistener | regex_search("yes|true|1|udp|tcp", ignorecase=True) )

--- a/roles/systemd_resolved/tasks/resolv.conf.yml
+++ b/roles/systemd_resolved/tasks/resolv.conf.yml
@@ -1,5 +1,5 @@
 ---
-- name: ensure resolv.conf (classic)
+- name: Ensure resolv.conf (classic)
   ansible.builtin.file:
     src: /run/systemd/resolve/resolv.conf
     dest: /etc/resolv.conf
@@ -8,7 +8,7 @@
   become: true
   when: ( systemd_resolved_dnsstublistener | regex_search("no|false|0", ignorecase=True) )
 
-- name: ensure resolv.conf (stub)
+- name: Ensure resolv.conf (stub)
   ansible.builtin.file:
     src: /run/systemd/resolve/stub-resolv.conf
     dest: /etc/resolv.conf

--- a/roles/systemd_resolved/tasks/systemd_service.yml
+++ b/roles/systemd_resolved/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_resolved_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_resolved_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_service/tasks/main.yml
+++ b/roles/systemd_service/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Ensure {{ systemd_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_service_name }}
   tags:
     - service
     - systemd_service
     - systemd
   block:
-    - name: Ensure {{ systemd_service_name }} systemd service
+    - name: Ensure systemd service {{ systemd_service_name }}
       ansible.builtin.import_tasks: systemd_service.yml

--- a/roles/systemd_service/tasks/systemd_service.yml
+++ b/roles/systemd_service/tasks/systemd_service.yml
@@ -1,27 +1,27 @@
 ---
-- name: Ensure {{ systemd_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_service_name }}
   become: true
   when:
     - systemd_service_name | length
   block:
-    - name: Ensure {{ systemd_service_name }} systemd service is enabled
+    - name: Ensure systemd service is enabled {{ systemd_service_name }}
       ansible.builtin.systemd:
         name: "{{ systemd_service_name }}"
         enabled: "{{ systemd_service_enabled }}"
 
-    - name: Ensure {{ systemd_service_name }} systemd service is started
+    - name: Ensure systemd service is started {{ systemd_service_name }}
       ansible.builtin.systemd:
         name: "{{ systemd_service_name }}"
         state: "{{ systemd_service_state }}"
 
-    - name: Ensure {{ systemd_service_name }} systemd service is reloaded
+    - name: Ensure systemd service is reloaded {{ systemd_service_name }}
       ansible.builtin.systemd:
         name: "{{ systemd_service_name }}"
         state: reloaded
       when:
         - systemd_service_reload_on
 
-    - name: Ensure {{ systemd_service_name }} systemd service is restarted
+    - name: Ensure systemd service is restarted {{ systemd_service_name }}
       ansible.builtin.systemd:
         name: "{{ systemd_service_name }}"
         state: restarted

--- a/roles/systemd_timedated/tasks/systemd_service.yml
+++ b/roles/systemd_timedated/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_timedated_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_timedated_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_timesyncd/tasks/systemd_service.yml
+++ b/roles/systemd_timesyncd/tasks/systemd_service.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_timesyncd_service_name }} systemd service
+- name: Ensure systemd service {{ systemd_timesyncd_service_name }}
   ansible.builtin.include_role:
     name: damex.systemd.systemd_service
   vars:

--- a/roles/systemd_unit/tasks/main.yml
+++ b/roles/systemd_unit/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Ensure {{ systemd_unit_name }} systemd unit
+- name: Ensure systemd unit {{ systemd_unit_name }}
   tags:
     - unit
     - systemd_unit
     - systemd
   block:
-    - name: Ensure {{ systemd_unit_name }} systemd unit
+    - name: Ensure systemd unit {{ systemd_unit_name }}
       ansible.builtin.import_tasks: systemd_unit.yml

--- a/roles/systemd_unit/tasks/systemd_unit.yml
+++ b/roles/systemd_unit/tasks/systemd_unit.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure {{ systemd_unit_name }} systemd unit
+- name: Ensure systemd unit {{ systemd_unit_name }}
   ansible.builtin.template:
     src: unit.j2
     dest: "{{ systemd_unit_file }}"
@@ -13,7 +13,7 @@
   register: systemd_unit_state
   become: true
 
-- name: Ensure {{ systemd_unit_name }} systemd unit override directory
+- name: Ensure systemd unit override directory {{ systemd_unit_name }}
   ansible.builtin.file:
     path: "{{ systemd_unit_override_directory }}"
     owner: root
@@ -26,7 +26,7 @@
     - systemd_unit_override_name
   become: true
 
-- name: Ensure {{ systemd_unit_name }} systemd unit {{ systemd_unit_override_name }} override
+- name: Ensure override {{ systemd_unit_override_name }}
   ansible.builtin.template:
     src: unit.j2
     dest: "{{ systemd_unit_override_file }}"


### PR DESCRIPTION
We do not use the stub listener. Now the role respects this setting.